### PR TITLE
Update raspberry.sh to be verbose about apt-get output

### DIFF
--- a/installers/raspberry.sh
+++ b/installers/raspberry.sh
@@ -100,7 +100,7 @@ function verlt() { [ "$1" = "$2" ] && return 1 || verlte $1 $2 ;}
 # Update before first apt-get
 if [ $mac != 'Darwin' ]; then
 	echo -e "\e[96mUpdating packages ...\e[90m" | tee -a $logfile
-	echo apt-get log being saved to $aptgetlogile
+	echo "apt-get log being saved to $aptgetlogile"
 	upgrade=$false
 	update=$(sudo apt-get update > $aptgetlogfile 2>&1)
 	echo $update >> $logfile
@@ -124,7 +124,7 @@ if [ $mac != 'Darwin' ]; then
 		upgrade=$true
 	fi
 	if [ $upgrade -eq $true ]; then
-	   upgrade_result=$(sudo apt-get upgrade > $aptgetlogfile 2>&1)
+	   upgrade_result=$(sudo apt-get upgrade --assume-yes > $aptgetlogfile 2>&1)
 		 upgrade_rc=$?
 		 echo apt upgrade result ="rc=$upgrade_rc $upgrade_result" >> $logfile
 	fi

--- a/installers/raspberry.sh
+++ b/installers/raspberry.sh
@@ -100,7 +100,7 @@ function verlt() { [ "$1" = "$2" ] && return 1 || verlte $1 $2 ;}
 # Update before first apt-get
 if [ $mac != 'Darwin' ]; then
 	echo -e "\e[96mUpdating packages ...\e[90m" | tee -a $logfile
-	echo "apt-get log being saved to $aptgetlogile"
+	echo "apt-get log being saved to $aptgetlogfile"
 	upgrade=$false
 	update=$(sudo apt-get update > $aptgetlogfile 2>&1)
 	echo $update >> $logfile

--- a/installers/raspberry.sh
+++ b/installers/raspberry.sh
@@ -68,6 +68,7 @@ if [[ $logdir != *"MagicMirror/installers"* ]]; then
 	fi
 fi
 logfile=$logdir/install.log
+aptgetlogfile=$logdir/apt-get.log
 echo install log being saved to $logfile
 
 # Determine which Pi is running.
@@ -99,14 +100,15 @@ function verlt() { [ "$1" = "$2" ] && return 1 || verlte $1 $2 ;}
 # Update before first apt-get
 if [ $mac != 'Darwin' ]; then
 	echo -e "\e[96mUpdating packages ...\e[90m" | tee -a $logfile
+	echo apt-get log being saved to $aptgetlogile
 	upgrade=$false
-	update=$(sudo apt-get update 2>&1)
+	update=$(sudo apt-get update > $aptgetlogfile 2>&1)
 	echo $update >> $logfile
 	update_rc=$?
 	if [ $update_rc -ne 0 ]; then
 	 echo -e "\e[91mUpdate failed, retrying installation ...\e[90m" | tee -a $logfile
 	 if [ $(echo $update | grep "apt-secure" | wc -l) -eq 1 ]; then
-			update=$(sudo apt-get update --allow-releaseinfo-change 2>&1)
+			update=$(sudo apt-get update --allow-releaseinfo-change > $aptgetlogfile 2>&1)
 			update_rc=$?
 			echo $update >> $logfile
 			if [ $update_rc -ne 0 ]; then
@@ -122,7 +124,7 @@ if [ $mac != 'Darwin' ]; then
 		upgrade=$true
 	fi
 	if [ $upgrade -eq $true ]; then
-	   upgrade_result=$(sudo apt-get upgrade 2>&1)
+	   upgrade_result=$(sudo apt-get upgrade > $aptgetlogfile 2>&1)
 		 upgrade_rc=$?
 		 echo apt upgrade result ="rc=$upgrade_rc $upgrade_result" >> $logfile
 	fi

--- a/installers/raspberry.sh
+++ b/installers/raspberry.sh
@@ -68,7 +68,6 @@ if [[ $logdir != *"MagicMirror/installers"* ]]; then
 	fi
 fi
 logfile=$logdir/install.log
-aptgetlogfile=$logdir/apt-get.log
 echo install log being saved to $logfile
 
 # Determine which Pi is running.
@@ -100,15 +99,16 @@ function verlt() { [ "$1" = "$2" ] && return 1 || verlte $1 $2 ;}
 # Update before first apt-get
 if [ $mac != 'Darwin' ]; then
 	echo -e "\e[96mUpdating packages ...\e[90m" | tee -a $logfile
-	echo "apt-get log being saved to $aptgetlogfile"
+	aptget_logfile=$logdir/apt-get.log
+	echo "apt-get log being saved to $aptget_logfile"
 	upgrade=$false
-	update=$(sudo apt-get update > $aptgetlogfile 2>&1)
+	update=$(sudo apt-get update > $aptget_logfile 2>&1)
 	echo $update >> $logfile
 	update_rc=$?
 	if [ $update_rc -ne 0 ]; then
 	 echo -e "\e[91mUpdate failed, retrying installation ...\e[90m" | tee -a $logfile
 	 if [ $(echo $update | grep "apt-secure" | wc -l) -eq 1 ]; then
-			update=$(sudo apt-get update --allow-releaseinfo-change > $aptgetlogfile 2>&1)
+			update=$(sudo apt-get update --allow-releaseinfo-change > $aptget_logfile 2>&1)
 			update_rc=$?
 			echo $update >> $logfile
 			if [ $update_rc -ne 0 ]; then
@@ -124,7 +124,7 @@ if [ $mac != 'Darwin' ]; then
 		upgrade=$true
 	fi
 	if [ $upgrade -eq $true ]; then
-	   upgrade_result=$(sudo apt-get upgrade --assume-yes > $aptgetlogfile 2>&1)
+	   upgrade_result=$(sudo apt-get upgrade --assume-yes > $aptget_logfile 2>&1)
 		 upgrade_rc=$?
 		 echo apt upgrade result ="rc=$upgrade_rc $upgrade_result" >> $logfile
 	fi


### PR DESCRIPTION
All apt-get operations output are saved at $logdir/apt-get.log along install.log. 
Apt-get runs can takes several minutes during which the screen is empty. This will help users confusion by allowing them to tail the apt-get log for the live action.

> Please send your pull requests the develop branch.
> Don't forget to add the change to CHANGELOG.md.

**Note**: Sometimes the development moves very fast. It is highly
recommended that you update your branch of `develop` before creating a
pull request to send us your changes. This makes everyone's lives
easier (including yours) and helps us out on the development team.
Thanks!


* Does the pull request solve a **related** issue?
* If so, can you reference the issue?
* What does the pull request accomplish? Use a list if needed.
* If it includes major visual changes please add screenshots.
